### PR TITLE
Renamed fron electronome to etcnome, prounounced 'et-set-ronome'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# electronome
+# etcnome
 
 Programmable metronome.
-Try it out at https://jrkatz.github.io/electronome/
+Try it out at https://jrkatz.github.io/etcnome/

--- a/app/controls/controls.js
+++ b/app/controls/controls.js
@@ -1,4 +1,4 @@
-// Electronome - A programmable metronome
+// Etcnome - A programmable metronome
 // Copyright (C) 2020  Jacob Katz
 //
 // This program is free software: you can redistribute it and/or modify
@@ -40,11 +40,11 @@ const bindControls = (
 
 if (window) {
   let toRun = [];
-  if (Array.isArray(window.electronome)) {
-    toRun = window.electronome;
+  if (Array.isArray(window.etcnome)) {
+    toRun = window.etcnome;
   }
-  window.electronome = window.electronome || {};
-  window.electronome.bindControls = bindControls;
+  window.etcnome = window.etcnome || {};
+  window.etcnome.bindControls = bindControls;
 
   for (const fn of toRun) {
     fn();

--- a/app/etcnome.html
+++ b/app/etcnome.html
@@ -2,14 +2,14 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Electronome</title>
+    <title>Etcnome</title>
     <meta
       http-equiv="Content-Security-Policy"
       content="script-src 'self' 'unsafe-inline';"
     />
   </head>
   <body>
-    <h1>Electronome</h1>
+    <h1>Etcnome</h1>
     <div>
       <button name="play/pause" id="playPause"></button>
       <button name="stop" id="stop"></button>
@@ -32,8 +32,8 @@
     <script src="../lib/interpreter/parser.js"></script>
     <script src="./controls/controls.js" type="module"></script>
     <script type="text/javascript">
-      function onElectronomeLoad() {
-        window.electronome.bindControls(
+      function onEtcnomeLoad() {
+        window.etcnome.bindControls(
           document.getElementById("playPause"),
           document.getElementById("stop"),
           document.getElementById("repeatToggle"),
@@ -43,10 +43,10 @@
         );
       }
 
-      if (typeof window.electronome === "undefined") {
-        window.electronome = [onElectronomeLoad];
-      } else if (!Array.isArray(window.electronome)) {
-        onElectronomeLoad();
+      if (typeof window.etcnome === "undefined") {
+        window.etcnome = [onEtcnomeLoad];
+      } else if (!Array.isArray(window.etcnome)) {
+        onEtcnomeLoad();
       }
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
- Electronome - A programmable metronome
+ Etcnome - A programmable metronome
  Copyright (C) 2020  Jacob Katz
 
  This program is free software: you can redistribute it and/or modify
@@ -21,7 +21,7 @@
   <head></head>
   <body style="height: 100%">
     <iframe
-      src="https://jrkatz.github.io/electronome/app/electronome.html"
+      src="https://jrkatz.github.io/etcnome/app/etcnome.html"
       width="100%"
       height="100%"
       border="none"

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ function createWindow() {
     height: 600,
   });
 
-  win.loadFile("app/electronome.html");
+  win.loadFile("app/etcnome.html");
 }
 
 app.whenReady().then(createWindow);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "electronome",
+  "name": "etcnome",
   "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "electronome",
+  "name": "etcnome",
   "version": "0.0.4",
   "main": "main.js",
   "scripts": {
@@ -9,20 +9,20 @@
   "description": "programmable metronome",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jrkatz/electronome.git"
+    "url": "git+https://github.com/jrkatz/etcnome.git"
   },
   "keywords": [
     "programmable",
     "metronome",
     "electron",
-    "electronome"
+    "etcnome"
   ],
   "author": "Jacob Katz",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
-    "url": "https://github.com/jrkatz/electronome/issues"
+    "url": "https://github.com/jrkatz/etcnome/issues"
   },
-  "homepage": "https://github.com/jrkatz/electronome#readme",
+  "homepage": "https://github.com/jrkatz/etcnome#readme",
   "devDependencies": {
     "electron": "^11.0.3",
     "eslint": "^7.14.0",

--- a/parser.jison
+++ b/parser.jison
@@ -1,4 +1,4 @@
-// Electronome - A programmable metronome
+// Etcnome - A programmable metronome
 // Copyright (C) 2020  Jacob Katz
 //
 // This program is free software: you can redistribute it and/or modify
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-/* description: Parses electronome metronome config language 
+/* description: Parses etcnome metronome config language 
  * (final name TBD) to an easy-to-read AST
  */
 


### PR DESCRIPTION
Not surprisingly, perhaps, 'electronome' was already the name of some metronome software.