### PR TITLE
Support for additive meters

### DIFF
--- a/lib/interpreter/interpreter.js
+++ b/lib/interpreter/interpreter.js
@@ -17,33 +17,32 @@
 import Measure from "../player/measure.js";
 import { SectionList, RepeatingSection } from "../player/section.js";
 
-const placeholderTxt = `120 bpm
+const placeholderTxt = `bpm 120
 4/4
 // Try this`;
 
 const demoTxt = `// Every track starts with a tempo,
-// which is a number followed by BPM
-// (It's not case sensitive, and can come
-// with or without a space.)
+// which is a number preceded by BPM
+// (It's not case sensitive)
 
-120bpm
+bpm 120
 
 // and needs something to play.
 // How about a bar of 4/4
 
 4/4
 
-// Press the play button ("|>") to see how 
+// Press the play button ("|>") to see how
 // it sounds.
 
 // That's pretty short, so check the 'Repeat'
 // box above to let it go forever.
 // Uncheck 'repeat' or press 'stop'("[ ]")
 // to... stop.
-// You can also pause with the pause ("||") 
+// You can also pause with the pause ("||")
 // button and press play again to resume.
 
-// Lines starting with // are ignored as 
+// Lines starting with // are ignored as
 // comments.
 // To play another bar, perhaps with a
 // different meter, after the first,
@@ -56,7 +55,7 @@ const demoTxt = `// Every track starts with a tempo,
 // Now let's do a third bar, at a different
 // pace.
 
-// 140.5 bpm // Uncomment me
+// bpm 140.5 // Uncomment me
 // 6/4 // Uncomment me too
 
 // To repeat a bar more than once, try
@@ -68,10 +67,10 @@ const demoTxt = `// Every track starts with a tempo,
 // with tempo change instructions. At the end
 // the original tempo will be restored:
 
-// 130bpm // Set original tempo
+// bpm 130 // Set original tempo
 // ( // Begin listing bars to repeat
 //   4/4 x 2 // two bars of 4
-//   160 BPM //speed up
+//   BPM 160 //speed up
 //   5/4 * 3 // three bars of 5
 // ) x 2 // do it all twice
 // 4/4 // this bar of 4 will play at 130bpm
@@ -85,7 +84,7 @@ const demoTxt = `// Every track starts with a tempo,
 // becomes 26400 beats/minute. That sounds
 // familiar.... Try this:
 
-// 26400 bpm
+// bpm 26400
 // 1/4 * 100
 
 // Note the tone that comes out is not a 440hz

--- a/lib/interpreter/parser.js
+++ b/lib/interpreter/parser.js
@@ -72,12 +72,12 @@
   }
 */
 var parser = (function(){
-var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[1,9],$V1=[1,10],$V2=[1,5],$V3=[1,6],$V4=[1,7],$V5=[17,18,19],$V6=[1,8,9,14,23,24],$V7=[8,9,11,15,17,18,19,25],$V8=[2,4],$V9=[1,22],$Va=[1,21],$Vb=[1,23],$Vc=[1,24],$Vd=[15,17,18,19],$Ve=[17,18,19,25];
+var o=function(k,v,o,l){for(o=o||{},l=k.length;l--;o[k[l]]=v);return o},$V0=[1,8],$V1=[1,5],$V2=[1,6],$V3=[1,7],$V4=[19,20,21],$V5=[1,8,13,16,29,30],$V6=[1,16],$V7=[1,17],$V8=[1,23],$V9=[1,25],$Va=[8,10,17,19,20,21,31],$Vb=[19,20,21,31],$Vc=[1,30],$Vd=[17,19,20,21];
 var parser = {trace: function trace () { },
 yy: {},
-symbols_: {"error":2,"track":3,"init_bpm":4,"eol":5,"instructions":6,"number":7,"WHOLE_NUMBER":8,"DECIMAL_NUMBER":9,"bpm":10,"BPM":11,"number_list":12,"swing":13,"SWING":14,"DOT_DOT_DOT":15,"OFF":16,"EOL":17,"EOF":18,"COMMENT":19,"instruction":20,"section":21,"/":22,"(":23,")":24,"*":25,"$accept":0,"$end":1},
-terminals_: {2:"error",8:"WHOLE_NUMBER",9:"DECIMAL_NUMBER",11:"BPM",14:"SWING",15:"DOT_DOT_DOT",16:"OFF",17:"EOL",18:"EOF",19:"COMMENT",22:"/",23:"(",24:")",25:"*"},
-productions_: [0,[3,3],[3,2],[3,1],[7,1],[7,1],[4,2],[4,1],[10,2],[12,1],[12,2],[13,2],[13,4],[13,2],[5,1],[5,1],[5,2],[5,2],[6,2],[6,3],[20,1],[20,1],[20,1],[21,3],[21,3],[21,4],[21,3]],
+symbols_: {"error":2,"track":3,"init_bpm":4,"eol":5,"instructions":6,"whole_number":7,"WHOLE_NUMBER":8,"decimal_number":9,"DECIMAL_NUMBER":10,"number":11,"bpm":12,"BPM":13,"number_list":14,"swing":15,"SWING":16,"DOT_DOT_DOT":17,"OFF":18,"EOL":19,"EOF":20,"COMMENT":21,"instruction":22,"section":23,"measure_num":24,"+":25,"measure_denom":26,"measure":27,"/":28,"(":29,")":30,"*":31,"$accept":0,"$end":1},
+terminals_: {2:"error",8:"WHOLE_NUMBER",10:"DECIMAL_NUMBER",13:"BPM",16:"SWING",17:"DOT_DOT_DOT",18:"OFF",19:"EOL",20:"EOF",21:"COMMENT",25:"+",28:"/",29:"(",30:")",31:"*"},
+productions_: [0,[3,3],[3,2],[3,1],[7,1],[9,1],[11,1],[11,1],[4,2],[4,1],[12,2],[14,1],[14,2],[15,2],[15,4],[15,2],[5,1],[5,1],[5,2],[5,2],[6,2],[6,3],[22,1],[22,1],[22,1],[24,1],[24,3],[26,1],[27,3],[23,1],[23,3],[23,4],[23,3]],
 performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {
 /* this == yyval */
 
@@ -99,54 +99,64 @@ case 3:
         return ["instrs"];
         
 break;
-case 6:
- this.$ = $$[$0]; 
+case 4: case 5:
+ this.$ = Number($$[$0]); 
 break;
 case 8:
- this.$ = ["bpm", $$[$0-1]]; 
-break;
-case 9:
- this.$ = [$$[$0]]; 
+ this.$ = $$[$0]; 
 break;
 case 10:
+ this.$ = ["bpm", $$[$0]]; 
+break;
+case 11: case 25:
+ this.$ = [$$[$0]]; 
+break;
+case 12:
 
  		tmp = $$[$0];
 		tmp.splice(0, 0, $$[$0-1]);
 		this.$ = tmp;
 	
 break;
-case 11:
+case 13:
  this.$ = ["swing", {ratios: $$[$0]}]; 
 break;
-case 12:
+case 14:
  this.$ = ["swing", {ratios: $$[$0-2], phrase: $$[$0]}]; 
 break;
-case 13:
+case 15:
  this.$ = ["swing", null]; 
 break;
-case 18:
+case 20:
  this.$ = [ "instrs", $$[$0-1] ]; 
 break;
-case 19:
+case 21:
  
           tmp = $$[$0];
           tmp.splice(1, 0, $$[$0-2]);
           this.$ = tmp;
         
 break;
-case 23:
+case 26:
+
+          tmp = $$[$0];
+          tmp.splice(0,0,$$[$0-2]);
+          this.$ = tmp;
+        
+break;
+case 28:
  this.$ = ["Measure", $$[$0-2], $$[$0]]; 
 break;
-case 24: case 25:
+case 30: case 31:
  this.$ = $$[$0-1]; 
 break;
-case 26:
+case 32:
  this.$ = ["RepeatingSection", $$[$0-2], $$[$0]]; 
 break;
 }
 },
-table: [{3:1,4:2,5:3,7:8,8:$V0,9:$V1,10:4,17:$V2,18:$V3,19:$V4},{1:[3]},{5:11,17:$V2,18:$V3,19:$V4},{1:[2,3],7:8,8:$V0,9:$V1,10:12},o($V5,[2,7]),o($V6,[2,14],{5:13,17:$V2,18:$V3,19:$V4}),o($V6,[2,15]),{5:14,17:$V2,18:$V3,19:$V4},{11:[1,15]},o($V7,$V8),o($V7,[2,5]),{1:[2,2],6:16,7:8,8:$V9,9:$V1,10:18,13:19,14:$Va,20:17,21:20,23:$Vb},o($V5,[2,6]),o($V6,[2,16]),o($V6,[2,17]),o($V5,[2,8]),{1:[2,1]},{5:24,17:$V2,18:$V3,19:$V4},o($V5,[2,20]),o($V5,[2,21]),o($V5,[2,22],{25:[1,25]}),{7:28,8:$V0,9:$V1,12:26,16:[1,27]},{11:$V8,22:[1,29]},{5:31,6:30,7:8,8:$V9,9:$V1,10:18,13:19,14:$Va,17:$V2,18:$V3,19:$V4,20:17,21:20,23:$Vb},o($Vc,[2,18],{7:8,20:17,10:18,13:19,21:20,6:32,8:$V9,9:$V1,14:$Va,23:$Vb}),{8:[1,33]},o($V5,[2,11],{15:[1,34]}),o($V5,[2,13]),o($Vd,[2,9],{7:28,12:35,8:$V0,9:$V1}),{7:36,8:$V0,9:$V1},{24:[1,37]},{6:38,7:8,8:$V9,9:$V1,10:18,13:19,14:$Va,20:17,21:20,23:$Vb},o($Vc,[2,19]),o($Ve,[2,26]),{8:[1,39]},o($Vd,[2,10]),o($Ve,[2,23]),o($Ve,[2,24]),{24:[1,40]},o($V5,[2,12]),o($Ve,[2,25])],
-defaultActions: {16:[2,1]},
+table: [{3:1,4:2,5:3,12:4,13:$V0,19:$V1,20:$V2,21:$V3},{1:[3]},{5:9,19:$V1,20:$V2,21:$V3},{1:[2,3],12:10,13:$V0},o($V4,[2,9]),o($V5,[2,16],{5:11,19:$V1,20:$V2,21:$V3}),o($V5,[2,17]),{5:12,19:$V1,20:$V2,21:$V3},{7:14,8:$V6,9:15,10:$V7,11:13},{1:[2,2],6:18,7:27,8:$V6,12:20,13:$V0,15:21,16:$V8,22:19,23:22,24:26,27:24,29:$V9},o($V4,[2,8]),o($V5,[2,18]),o($V5,[2,19]),o($V4,[2,10]),o($Va,[2,6]),o($Va,[2,7]),o([8,10,17,19,20,21,25,28,31],[2,4]),o($Va,[2,5]),{1:[2,1]},{5:28,19:$V1,20:$V2,21:$V3},o($V4,[2,22]),o($V4,[2,23]),o($V4,[2,24],{31:[1,29]}),{7:14,8:$V6,9:15,10:$V7,11:32,14:30,18:[1,31]},o($Vb,[2,29]),{5:34,6:33,7:27,8:$V6,12:20,13:$V0,15:21,16:$V8,19:$V1,20:$V2,21:$V3,22:19,23:22,24:26,27:24,29:$V9},{28:[1,35]},{25:[1,36],28:[2,25]},o($Vc,[2,20],{22:19,12:20,15:21,23:22,27:24,24:26,7:27,6:37,8:$V6,13:$V0,16:$V8,29:$V9}),{7:38,8:$V6},o($V4,[2,13],{17:[1,39]}),o($V4,[2,15]),o($Vd,[2,11],{7:14,9:15,11:32,14:40,8:$V6,10:$V7}),{30:[1,41]},{6:42,7:27,8:$V6,12:20,13:$V0,15:21,16:$V8,22:19,23:22,24:26,27:24,29:$V9},{7:14,8:$V6,9:15,10:$V7,11:44,26:43},{7:27,8:$V6,24:45},o($Vc,[2,21]),o($Vb,[2,32]),{7:46,8:$V6},o($Vd,[2,12]),o($Vb,[2,30]),{30:[1,47]},o($Vb,[2,28]),o($Vb,[2,27]),{28:[2,26]},o($V4,[2,14]),o($Vb,[2,31])],
+defaultActions: {18:[2,1],45:[2,26]},
 parseError: function parseError (str, hash) {
     if (hash.recoverable) {
         this.trace(str);
@@ -625,40 +635,42 @@ var YYSTATE=YY_START;
 switch($avoiding_name_collisions) {
 case 0:/* skip whitespace */
 break;
-case 1:return 19;
+case 1:return 21;
 break;
-case 2:return 15;
+case 2:return 17;
 break;
-case 3:return 9;
+case 3:return 10;
 break;
 case 4:return 8;
 break;
-case 5:return 11;
+case 5:return 13;
 break;
-case 6:return 14;
+case 6:return 16;
 break;
-case 7:return 16;
+case 7:return 18;
 break;
 case 8:return 25;
 break;
-case 9:return 25;
+case 9:return 31;
 break;
-case 10:return 22
+case 10:return 31;
 break;
-case 11:return 23;
+case 11:return 28
 break;
-case 12:return 24;
+case 12:return 29;
 break;
-case 13:return 19;
+case 13:return 30;
 break;
-case 14:return 17;
+case 14:return 21;
 break;
-case 15:return 18;
+case 15:return 19;
+break;
+case 16:return 20;
 break;
 }
 },
-rules: [/^(?:[ \t]+)/,/^(?:\/\/[^\n]*)/,/^(?:\.\.\.)/,/^(?:[0-9]+\.[0-9]+)/,/^(?:[0-9]+)/,/^(?:\b[Bb][Pp][Mm]\b)/,/^(?:\b[Ss][[Ww][Ii][Nn][Gg]\b)/,/^(?:\b[Oo][Ff][Ff]\b)/,/^(?:\*)/,/^(?:x\b)/,/^(?:\/)/,/^(?:\()/,/^(?:\))/,/^(?:\/\/)/,/^(?:\n)/,/^(?:$)/],
-conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15],"inclusive":true}}
+rules: [/^(?:[ \t]+)/,/^(?:\/\/[^\n]*)/,/^(?:\.\.\.)/,/^(?:[0-9]+\.[0-9]+)/,/^(?:[0-9]+)/,/^(?:\b[Bb][Pp][Mm]\b)/,/^(?:\b[Ss][[Ww][Ii][Nn][Gg]\b)/,/^(?:\b[Oo][Ff][Ff]\b)/,/^(?:\+)/,/^(?:\*)/,/^(?:x\b)/,/^(?:\/)/,/^(?:\()/,/^(?:\))/,/^(?:\/\/)/,/^(?:\n)/,/^(?:$)/],
+conditions: {"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"inclusive":true}}
 });
 return lexer;
 })();

--- a/lib/player/measure.js
+++ b/lib/player/measure.js
@@ -21,7 +21,7 @@
 // classes, which also extend Section.
 
 import { Section } from "./section.js";
-import { clickHigh, clickLow } from "../noises/click.js";
+import { clickHigh, clickMid, clickLow } from "../noises/click.js";
 import Beat from "./beat.js";
 
 const makeSwingLookup = (swing, count, clickDuration) => {
@@ -59,18 +59,26 @@ const makeSwingLookup = (swing, count, clickDuration) => {
 };
 
 class Measure extends Section {
-  constructor({ bpm, swing }, count, denom = 4, subdivision = 1) {
+  constructor({ bpm, swing }, counts, denom = 4, subdivision = 1) {
     super([clickHigh, clickLow]);
-    this.count = count;
-
-    this.count = subdivision * count;
+    const totalCount = counts.reduce((a, b) => a + b);
+    let ctTotal = 0;
+    // pick downbeats
+    this.downbeats = new Set([
+      ...counts.slice(0, -1).map((ct) => {
+        ctTotal += ct * subdivision;
+        return ctTotal;
+      }),
+    ]);
+    this.count = subdivision * totalCount;
     this.baseBeatDuration = (60 / bpm) * (4 / denom);
     const clickDuration = this.baseBeatDuration / subdivision;
 
     this.getClickDuration = swing
-      ? makeSwingLookup(swing, count, clickDuration)
+      ? makeSwingLookup(swing, totalCount, clickDuration)
       : () => clickDuration;
 
+    // first beat always gets a high note.
     this.firstBeat = new Beat(this.getClickDuration(0), clickHigh, this, 0);
   }
 
@@ -85,7 +93,12 @@ class Measure extends Section {
       return null;
     }
 
-    const beat = new Beat(this.getClickDuration(count), clickLow, this, count);
+    const beat = new Beat(
+      this.getClickDuration(count),
+      this.downbeats.has(count) ? clickMid : clickLow,
+      this,
+      count
+    );
     return beat;
   }
 }

--- a/parser.jison
+++ b/parser.jison
@@ -17,7 +17,6 @@
 /* description: Parses etcnome metronome config language 
  * (final name TBD) to an easy-to-read AST
  */
-
 /* lexical grammar */
 %lex
 
@@ -30,6 +29,7 @@
 \b[Bb][Pp][Mm]\b            return 'BPM';
 \b[Ss][[Ww][Ii][Nn][Gg]\b   return 'SWING';
 \b[Oo][Ff][Ff]\b            return 'OFF';
+"+"                         return '+';
 "*"                         return '*';
 "x"                         return '*';
 "/"                         return '/'
@@ -64,9 +64,18 @@ track
         }
     ;
 
-number
+whole_number
     : WHOLE_NUMBER
-    | DECIMAL_NUMBER
+      { $$ = Number($1); }
+    ;
+decimal_number
+    : DECIMAL_NUMBER
+      { $$ = Number($1); }
+    ;
+
+number
+    : whole_number
+    | decimal_number
     ;
 
 /* allow newlines at the top of the file before the first bpm */
@@ -78,8 +87,8 @@ init_bpm
 
 /* an instruction that sets the bpm for subsequent instructions in the same scope */
 bpm
-    : number BPM
-        { $$ = ["bpm", $1]; }
+    : BPM number
+        { $$ = ["bpm", $2]; }
     ;
 
 number_list
@@ -96,7 +105,7 @@ number_list
 swing
     : SWING number_list
 	{ $$ = ["swing", {ratios: $2}]; }
-    | SWING number_list DOT_DOT_DOT WHOLE_NUMBER
+    | SWING number_list DOT_DOT_DOT whole_number
 	{ $$ = ["swing", {ratios: $2, phrase: $4}]; }
     | SWING OFF
  	{ $$ = ["swing", null]; }
@@ -130,13 +139,32 @@ instruction
     | section
     ;
 
-section
-    : WHOLE_NUMBER '/' number
+measure_num
+    : whole_number
+        { $$ = [$1]; }
+    | whole_number '+' measure_num
+        {
+          tmp = $3;
+          tmp.splice(0,0,$1);
+          $$ = tmp;
+        }
+    ;
+
+measure_denom
+    : number
+    ;
+
+measure
+    : measure_num '/' measure_denom
         { $$ = ["Measure", $1, $3]; }
+    ;
+
+section
+    : measure
     | '(' instructions ')'
         { $$ = $2; }
     | '(' eol instructions ')'
         { $$ = $3; }
-    | section '*' WHOLE_NUMBER
+    | section '*' whole_number
         { $$ = ["RepeatingSection", $1, $3]; }
     ;


### PR DESCRIPTION
For example, instead of '7/4', one can write '4+3/4' to denote that we
emphasize the 4th beat.

This required a breaking change: the syntax for declaring bpm is less
natural, because we now put 'bpm' before the number. I might later look
for a way to specify the parsing such that putting 'bpm' after the
number reduces conflicts, but for now this is good enough.

Closes #30 