### PR TITLE
Audio separated from sections/timing information

### DIFF
--- a/app/controls/transport.js
+++ b/app/controls/transport.js
@@ -81,7 +81,6 @@ class Transport {
   }
 
   controlsStopped() {
-    this.player.stop();
     this.playEnabled();
     this.stopDisabled();
     this.editor.setEnabled(true);
@@ -109,7 +108,7 @@ class Transport {
     this.editor.setEnabled(true);
   }
 
-  controlsExporting() {
+  controlsThinking() {
     this.playDisabled();
     this.stopDisabled();
     this.exportDisabled();
@@ -123,8 +122,8 @@ class Transport {
       this.controlsPaused();
     } else if (state === State.stopped) {
       this.controlsStopped();
-    } else if (state === State.exporting) {
-      this.controlsExporting();
+    } else if (state === State.thinking) {
+      this.controlsThinking();
     } else {
       // default to empty
       this.controlsEmpty();

--- a/lib/noises/click.js
+++ b/lib/noises/click.js
@@ -29,7 +29,7 @@ const attackRelease = (audioCtx, source, attack, decay, start = 0) => {
   return envelope;
 };
 
-const normalize = (buffer) => {
+const normalize = (buffer, norm) => {
   // pretend we did anything.
   let max = 0;
   for (let i = 0; i < buffer.numberOfChannels; i += 1) {
@@ -40,12 +40,12 @@ const normalize = (buffer) => {
     );
   }
 
-  if (max !== 1) {
+  if (max !== norm) {
     // normalize stuff:
     for (let i = 0; i < buffer.numberOfChannels; i += 1) {
       const channel = buffer.getChannelData(i);
       for (let j = 0; j < channel.length; j += 1) {
-        channel[j] *= max / 1;
+        channel[j] *= norm / max;
       }
     }
   }
@@ -53,7 +53,7 @@ const normalize = (buffer) => {
   return buffer;
 };
 
-const click = (frequency, attack, decay, sampleRate) => {
+const click = (frequency, attack, decay, sampleRate, vol = 1) => {
   const length = (attack + decay) * sampleRate;
 
   const audioCtx = new OfflineAudioContext(1, length, sampleRate);
@@ -79,9 +79,7 @@ const click = (frequency, attack, decay, sampleRate) => {
     } else {
       audioCtx.oncomplete = (result) => resolve(result.renderedBuffer);
     }
-  }).then(normalize);
+  }).then((buf) => normalize(buf, vol));
 };
 
-export const clickHigh = click(2000, 0.0001, 0.04, 44100);
-export const clickMid = click(1000, 0.0001, 0.04, 44100);
-export const clickLow = click(500, 0.0001, 0.04, 44100);
+export default click;

--- a/lib/player/beatList.js
+++ b/lib/player/beatList.js
@@ -23,13 +23,13 @@
 // This section represents a list of arbitrary beats.
 
 import { Section } from "./section.js";
-import { clickHigh, clickMid, clickLow } from "../noises/click.js";
-import Beat from "./beat.js";
+import SoundSpec from "./soundSpec.js";
+import Sound from "./sound.js";
 
 class BeatList extends Section {
   // TODO break this up. It's a monster.
   constructor({ bpm }, beats) {
-    super([clickHigh, clickMid, clickLow]);
+    super();
     this.beats = beats;
     this.bpm = bpm;
   }
@@ -44,20 +44,25 @@ class BeatList extends Section {
     const [durationType, durationVal] = durationSpec;
     const duration =
       durationType === "exact" ? durationVal : (durationVal * 60) / this.bpm;
-    let click = null;
+    let tone = null;
     switch (intensity) {
       case "HIGH":
-        click = clickHigh;
+        tone = 0;
         break;
       case "MID":
-        click = clickMid;
+        tone = 1;
         break;
       default:
-        click = clickLow;
+        tone = 2;
         break;
     }
 
-    const beat = new Beat(duration, click, this, count);
+    const beat = new Sound(
+      duration,
+      new SoundSpec({ tone, vol: 1, instr: 0 }),
+      this,
+      count
+    );
     return beat;
   }
 }

--- a/lib/player/beaterator.js
+++ b/lib/player/beaterator.js
@@ -35,10 +35,10 @@ class Beaterator {
       return null;
     }
     this.lastBeat = nextBeat;
-    const { buffer, duration } = nextBeat;
+    const { soundSpec, duration } = nextBeat;
     const time = this.nextTime;
     this.nextTime += duration;
-    return { buffer, time };
+    return { soundSpec, time };
   }
 }
 

--- a/lib/player/ensemble.js
+++ b/lib/player/ensemble.js
@@ -1,0 +1,19 @@
+import Click from "../noises/click.js";
+
+export default class Ensemble {
+  constructor() {
+    this.clicks = new Map();
+  }
+
+  getSound(soundSpec, sampleRate) {
+    const { tone, vol, instr } = soundSpec;
+    const key = `${tone}|${vol}|${instr}|${sampleRate}`;
+    let click = this.clicks.get(key);
+    if (!click) {
+      const pitch = 2000 / 2 ** tone;
+      click = Click(pitch, 0.0001, 0.04, sampleRate);
+      this.clicks.set(key, click);
+    }
+    return click;
+  }
+}

--- a/lib/player/measure.js
+++ b/lib/player/measure.js
@@ -21,13 +21,13 @@
 // classes, which also extend Section.
 
 import { Section } from "./section.js";
-import { clickHigh, clickMid, clickLow } from "../noises/click.js";
-import Beat from "./beat.js";
+import SoundSpec from "./soundSpec.js";
+import Sound from "./sound.js";
 
 class Measure extends Section {
   // TODO break this up. It's a monster.
   constructor({ bpm, swing }, rhythms, denom = 4, subdivision = 1) {
-    super([clickHigh, clickMid, clickLow]);
+    super();
     // something totally different for polyrhythms
     // total each count,
     const polyCounts = rhythms.map((phrases) =>
@@ -120,45 +120,69 @@ class Measure extends Section {
     // beatRhythms has which rhythms the beat is in (it may be in more than
     // one) for now we'll emphasize any beat that is in more than one rhythm
     // or is a downbeat in any one rhythm.
-
     const beatClicks = beatRhythms.map((beatRs, beatIdx) => {
+      // first beat is always a high click in the main instrument
       if (beatIdx === 0) {
-        return clickHigh;
+        return new SoundSpec({ tone: 0, vol: 1, instr: 0 });
       }
-      if (beatRs.length > 1) {
-        return clickMid;
+      // by default beats have tone 2. To add emphasis, we bring the tone closer
+      // to 0.
+      let tone = 2;
+      // go down to half volume for the last rhythm.
+      const volPerRhythm = 0.5 / rhythms.length;
+
+      const firstRhythm = beatRs.reduce((a, b) => Math.min(a, b));
+      // detune slightly to make rhythms more distinguishable
+      tone *= 1.1 ** firstRhythm;
+      // pick instrument and volume based on the _first_ rhythm we appear in
+      const vol = 1 - firstRhythm * volPerRhythm;
+      const instr = firstRhythm;
+
+      const beatRhythmEmphasis = beatRs.map((r) => {
+        const counts = rhythms[r];
+
+        const chunk = beatChunks[beatIdx];
+        // work out chunks per beat of this rhythm, then divide that into the
+        // current chunk to see which beat of this rhythm we are on.
+        const idxInRhythm = chunk / (chunks / polyCounts[r]);
+        // decide if the beat is a downbeat in its rhythm
+        if (counts.length === 1) {
+          // For once '&' is not a typo for '&&'
+          // eslint-disable-next-line no-bitwise
+          if (counts[0] % 3 === 0 && denom > 4 && (denom & (denom - 1)) === 0) {
+            // the numerator is divisible by three and the bottom is a power of
+            // 2 greater than 4. Traditionally, this suggests a compound time,
+            // i.e. beats are played in groups of 3.
+            // Figure out if this beat is a third beat in its count:
+
+            return idxInRhythm % (3 * subdivision) === 0
+              ? [r, true]
+              : [r, false];
+          }
+        } else {
+          const downbeats = new Set();
+          let sofar = 0;
+          for (const count of counts) {
+            sofar += count;
+            downbeats.add(sofar);
+          }
+          if (downbeats.has(idxInRhythm)) {
+            return [r, true];
+          }
+        }
+        return [r, false];
+      });
+
+      const baseTone = tone;
+      for (const rhythmEm of beatRhythmEmphasis) {
+        const [rhythm, emphasized] = rhythmEm;
+        const ratio = emphasized ? 2 : 1 + (1 - 0.9 ** rhythm);
+        const diff = baseTone - baseTone / ratio;
+        // apply the difference, but weaken it based on which rhythm is used:
+        tone -= diff / 2 ** rhythm;
       }
 
-      const counts = rhythms[beatRs[0]];
-
-      const chunk = beatChunks[beatIdx];
-      // work out chunks per beat of this rhythm, then divide that into the
-      // current chunk to see which beat of this rhythm we are on.
-      const idxInRhythm = chunk / (chunks / polyCounts[beatRs]);
-      // decide if the beat is a downbeat in its rhythm
-      if (counts.length === 1) {
-        // For once '&' is not a typo for '&&'
-        // eslint-disable-next-line no-bitwise
-        if (counts[0] % 3 === 0 && denom > 4 && (denom & (denom - 1)) === 0) {
-          // the numerator is divisible by three and the bottom is a power of 2
-          // greater than 4. Traditionally, this suggests a compound time, i.e.
-          // beats are played in groups of 3.
-          // figure out if this beat is a third beat in its count:
-
-          return idxInRhythm % (3 * subdivision) === 0 ? clickMid : clickLow;
-        }
-      } else {
-        const downbeats = new Set();
-        let sofar = 0;
-        for (const count of counts) {
-          sofar += count;
-          downbeats.add(sofar);
-        }
-        if (downbeats.has(idxInRhythm)) {
-          return clickMid;
-        }
-      }
-      return clickLow;
+      return new SoundSpec({ tone, vol, instr });
     });
     this.beatClicks = beatClicks;
     this.beatDurations = beatDurations;
@@ -171,7 +195,7 @@ class Measure extends Section {
       return null;
     }
 
-    const beat = new Beat(
+    const beat = new Sound(
       this.beatDurations[count],
       this.beatClicks[count],
       this,

--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -32,6 +32,7 @@ import Beaterator from "./beaterator.js";
 import recorder from "./recorder.js";
 import wavExport from "../util/wavExport.js";
 import fileUtil from "../util/fileUtil.js";
+import Ensemble from "./ensemble.js";
 
 // Delay the start of playback this long. Necessary because some browsers can't
 // successfully play the first few milliseconds of audio, even if it scheduled
@@ -49,7 +50,7 @@ const START_DELAY = 0.1;
 
 export const State = {
   empty: "empty", // stopped and unable to transition to playing
-  exporting: "exporting",
+  thinking: "thinking",
   stopped: "stopped",
   playing: "playing",
   paused: "paused",
@@ -70,6 +71,7 @@ class Player extends EventTarget {
   }
 
   setTrack(section) {
+    this.ensemble = new Ensemble();
     this.section = section;
     this.beaterator = new Beaterator(section, START_DELAY);
     // determine whether or not
@@ -82,9 +84,11 @@ class Player extends EventTarget {
     }
   }
 
-  reset(audioCtx) {
-    this.audioCtx?.close();
-    this.audioCtx = audioCtx;
+  reset() {
+    this.audioCtx?.close()?.catch(() => {
+      // close inexplicably fails instead of doing nothing if the context is
+      // already stopped. We 'handle' this by ignoring it.
+    });
     this.beaterator = new Beaterator(this.section, START_DELAY);
   }
 
@@ -94,20 +98,26 @@ class Player extends EventTarget {
 
   changeState(state, action) {
     if (this.state === state) {
-      return null;
-    }
-    const result = action();
-    if (result) {
-      this.state = state;
       this.messageState(state);
+      return Promise.resolve(state);
     }
-    return result;
+    this.messageState(State.thinking);
+    return action(this.state)
+      .then(() => {
+        this.state = state;
+        this.messageState(state);
+        return state;
+      })
+      .catch((err) => {
+        console.error(err);
+        return this.stop();
+      });
   }
 
   exportWav() {
-    const exportPromise = this.changeState(State.exporting, () => {
+    return this.changeState(State.thinking, () => {
       if (!this.section) {
-        return null;
+        return Promise.reject(new Error("Nothing to export"));
       }
       return recorder
         .record(this.section)
@@ -115,69 +125,66 @@ class Player extends EventTarget {
         .then((blob) =>
           fileUtil.saveFile(blob, ".wav file(s)", "audio/wav", [".wav"])
         );
-    });
-
-    if (exportPromise) {
-      exportPromise
-        .catch((err) => {
-          alert(`${err.name} ${err.message}`);
-          console.error(err);
-        })
-        .finally(() => this.stop());
-    } else {
-      // TODO guess there should be some message about why nothing happened.
-      // a typical cause would be that there was no track to export.
-      this.stop();
-    }
+    }).finally(() => this.stop());
   }
 
   empty() {
+    // ensure this always stops player, regardless
+    // the state the player thinks it is in.
+    this.reset();
     this.changeState(State.empty, () => {
-      this.reset();
-      return true;
+      return Promise.resolve();
     });
   }
 
   stop() {
+    // ensure that stop _always_ stops, regardless
+    // the state the player thinks it is in.
+    this.reset();
     this.changeState(State.stopped, () => {
-      this.reset();
-      return true;
+      return Promise.resolve();
     });
   }
 
   play() {
-    this.changeState(State.playing, () => {
-      if (this.audioCtx) {
-        this.audioCtx.resume();
-      } else if (this.section) {
-        this.section.ready().then(() => {
-          const audioCtx = new AudioContext();
-          audioCtx.suspend();
-          this.reset(audioCtx);
-          this.queue()?.then(() => audioCtx.resume());
-        });
-      } else {
-        return false;
+    this.changeState(State.playing, (prevState) => {
+      if (!this.section) {
+        return Promise.reject(new Error(`Nothing to play`));
       }
-      return true;
+      if (prevState !== State.paused) {
+        // queue something up
+        this.audioCtx = new AudioContext();
+        // to appease safari, we call resume right away in the event handler.
+        // The first time 'resume' is called cannot be in a callback, as then
+        // safari can't tie it to a user action and it trips the autoplay
+        // blockers. Other browsers are better at handling this.
+        // However, we also want to wait until we've queued beats to _actually_
+        // play audio:
+        return this.audioCtx
+          .resume()
+          .then(() => this.audioCtx.suspend())
+          .then(() => this.queue())
+          .then(() => this.audioCtx.resume());
+      }
+      return this.audioCtx.resume();
     });
   }
 
   pause() {
     this.changeState(State.paused, () => {
-      this.audioCtx.suspend();
-      return true;
+      return this.audioCtx.suspend();
     });
   }
 
-  schedule({ buffer, time }) {
-    return buffer.then((buf) => {
+  schedule({ soundSpec, time }) {
+    const click = this.ensemble.getSound(soundSpec, this.audioCtx.sampleRate);
+    return click.then((buffer) => {
       if (!this.audioCtx) {
         // handle race condition when player has stopped
         return null;
       }
       const source = this.audioCtx.createBufferSource();
-      source.buffer = buf;
+      source.buffer = buffer;
       source.connect(this.audioCtx.destination);
       source.start(time);
       return source;

--- a/lib/player/recorder.js
+++ b/lib/player/recorder.js
@@ -16,17 +16,18 @@
 
 // records a section (typically a whole track) to an AudioBuffer
 import Beaterator from "./beaterator.js";
+import Ensemble from "./ensemble.js";
 
 const record = (section) => {
   const beaterator = new Beaterator(section);
-  const beats = [];
+  const sounds = [];
   let next = beaterator.next();
   while (next !== null) {
-    beats.push(next);
+    sounds.push(next);
     next = beaterator.next();
   }
 
-  if (beats.length === 0) {
+  if (sounds.length === 0) {
     return Promise.resolve(null);
   }
 
@@ -42,8 +43,10 @@ const record = (section) => {
     sampleRate
   );
 
-  const scheduled = beats.map(({ buffer, time }) =>
-    buffer.then((buf) => {
+  const ensemble = new Ensemble();
+
+  const scheduled = sounds.map(({ soundSpec, time }) =>
+    ensemble.getSound(soundSpec, sampleRate).then((buf) => {
       const source = audioCtx.createBufferSource();
       source.buffer = buf;
       source.connect(audioCtx.destination);
@@ -51,6 +54,7 @@ const record = (section) => {
       source.start(time);
     })
   );
+
   return Promise.all(scheduled).then(
     () =>
       new Promise((resolve) => {

--- a/lib/player/section.js
+++ b/lib/player/section.js
@@ -21,24 +21,16 @@
 // classes, which also extend Section.
 
 export class Section {
-  constructor(requires = []) {
-    this.requires = requires;
-  }
-
   // eslint-disable-next-line no-unused-vars, class-methods-use-this
   nextBeat(prevBeat) {
     return null;
-  }
-
-  ready() {
-    return Promise.all(this.requires);
   }
 }
 
 // TODO fix off-by-one issues... the last bar is cut short by a beat. (at least)
 export class RepeatingSection extends Section {
   constructor(section, repeats) {
-    super([section.ready()]);
+    super();
     this.section = section;
     this.repeats = repeats;
   }
@@ -64,7 +56,7 @@ export class RepeatingSection extends Section {
 
 export class SectionList extends Section {
   constructor(sections) {
-    super(sections.map((section) => section.ready()));
+    super();
     this.sections = sections || [];
   }
 

--- a/lib/player/sound.js
+++ b/lib/player/sound.js
@@ -1,0 +1,46 @@
+// Etcnome - A programmable metronome
+// Copyright (C) 2020  Jacob Katz
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+class Sound {
+  constructor(duration, soundSpec, owner, meta) {
+    this.duration = duration;
+    this.soundSpec = soundSpec;
+
+    this.metaMap = new WeakMap();
+    if (owner && typeof meta !== "undefined") {
+      this.metaMap.set(owner, meta);
+    }
+  }
+
+  getMeta(owner, defaultVal) {
+    // falsey values like 0 kill the opportunity
+    // to use fewer lookups here. Oh well.
+    if (this.metaMap.has(owner)) {
+      return this.metaMap.get(owner);
+    }
+    return defaultVal;
+  }
+
+  hasMeta(owner) {
+    return this.metaMap.has(owner);
+  }
+
+  setMeta(owner, meta) {
+    this.metaMap.set(owner, meta);
+  }
+}
+
+export default Sound;

--- a/lib/player/soundSpec.js
+++ b/lib/player/soundSpec.js
@@ -14,33 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-class Beat {
-  constructor(duration, buffer, owner, meta) {
-    this.duration = duration;
-    this.buffer = buffer;
-
-    this.metaMap = new WeakMap();
-    if (owner && typeof meta !== "undefined") {
-      this.metaMap.set(owner, meta);
-    }
-  }
-
-  getMeta(owner, defaultVal) {
-    // falsey values like 0 kill the opportunity
-    // to use fewer lookups here. Oh well.
-    if (this.metaMap.has(owner)) {
-      return this.metaMap.get(owner);
-    }
-    return defaultVal;
-  }
-
-  hasMeta(owner) {
-    return this.metaMap.has(owner);
-  }
-
-  setMeta(owner, meta) {
-    this.metaMap.set(owner, meta);
+class SoundSpec {
+  constructor({ tone, vol, instr }) {
+    this.tone = tone;
+    this.vol = vol;
+    this.instr = instr;
   }
 }
 
-export default Beat;
+export default SoundSpec;


### PR DESCRIPTION
Rather than rely on the sections (ergo beaterator, etc) to provide the
audio players and recorders use, sections supply only scheduling and
emphasis information to players and recorders. These orchestrate audio
by passing the emphasis information to an ensemble, which in turn
provides the buffer to play. The downstream benefit here is that
ensembles can be swapped out, allowing easy customization of click
sounds later on.

Closes #46 